### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Bill is an agent that learns to play the game of tic-tac-toe with self-play usin
 - Run **trainPlayerX.py** to start training an agent. 
 - **tictactoe** contains the game environment of tictactoe, the agent definition and the code that simulates the training.
 - Required packages are found in **requirements.txt**, install by typing *pip install -r requirements.txt*
+
+[![Run on Repl.it](https://repl.it/badge/github/RickardKarl/bill-the-bot)](https://repl.it/github/RickardKarl/bill-the-bot)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).